### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export DISPLAY=:99
 git clone http://source.ffmpeg.org/git/ffmpeg.git ffmpeg
 cd ffmpeg
 
-ln -s ~/ffmpeg-gl-transition/vf_gltransition.c libavfilter/
+cp ~/ffmpeg-gl-transition/vf_gltransition.c libavfilter/
 git apply ~/ffmpeg-gl-transition/ffmpeg.diff
 
 ```


### PR DESCRIPTION
Creating symbolic link of vf_gltransition.c in libavfilter using ln-s causes build process to stop with error "make: *** No rule to make target `libavfilter/vf_gltransition.c', needed by `libavfilter/vf_gltransition.o'.  Stop."

Better to **copy vf_gltransition.c into libavfilter**