### PR TITLE
solve segmentation fault when eglGetDisplay failed to return display …

### DIFF
--- a/vf_gltransition.c
+++ b/vf_gltransition.c
@@ -22,6 +22,7 @@
 
 #ifdef GL_TRANSITION_USING_EGL
 # include <EGL/egl.h>
+# include <EGL/eglext.h>
 #else
 # include <GLFW/glfw3.h>
 #endif
@@ -291,7 +292,22 @@ static int setup_gl(AVFilterLink *inLink)
 #ifdef GL_TRANSITION_USING_EGL
   //init EGL
   // 1. Initialize EGL
-  c->eglDpy = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  // c->eglDpy = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+
+  #define MAX_DEVICES 4
+  EGLDeviceEXT eglDevs[MAX_DEVICES];
+  EGLint numDevices;
+
+  PFNEGLQUERYDEVICESEXTPROC eglQueryDevicesEXT =(PFNEGLQUERYDEVICESEXTPROC)
+  eglGetProcAddress("eglQueryDevicesEXT");
+
+  eglQueryDevicesEXT(MAX_DEVICES, eglDevs, &numDevices);
+
+  PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT =  (PFNEGLGETPLATFORMDISPLAYEXTPROC)
+  eglGetProcAddress("eglGetPlatformDisplayEXT");
+
+  c->eglDpy = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, eglDevs[0], 0);
+
   EGLint major, minor;
   eglInitialize(c->eglDpy, &major, &minor);
   av_log(ctx, AV_LOG_DEBUG, "%d%d", major, minor);


### PR DESCRIPTION
```
...
Stream mapping:
  Stream #0:0 (h264) -> gltransition:from (graph 0)
  Stream #1:0 (h264) -> gltransition:to (graph 0)
  gltransition (graph 0) -> Stream #0:0 (libx264)
  Stream #0:1 -> #0:1 (aac (native) -> aac (native))
Press [q] to stop, [?] for help
Segmentation fault (core dumped)
```
As can see in some issues (#41, #23, #19, #49), 
after compiled ffmpeg with enable gltransition successfully, there may cause segmentation fault in some environments when run ffmpeg command with gltransition filter, however we can avoid these issue by using this patch.