### PR TITLE
Try to keep alpha channel, and added input option「ex…

### DIFF
--- a/vf_gltransition.c
+++ b/vf_gltransition.c
@@ -7,9 +7,10 @@
 #include "libavutil/opt.h"
 #include "internal.h"
 #include "framesync.h"
+#include "video.h"
+#include "formats.h"
 
 #ifndef __APPLE__
-# define GL_TRANSITION_USING_EGL //remove this line if you don't want to use EGL
 #endif
 
 #ifdef __APPLE__
@@ -603,8 +604,7 @@ static const AVFilterPad gltransition_inputs[] = {
   {
     .name = "to",
     .type = AVMEDIA_TYPE_VIDEO,
-  },
-  {NULL}
+  }
 };
 
 static const AVFilterPad gltransition_outputs[] = {
@@ -612,8 +612,7 @@ static const AVFilterPad gltransition_outputs[] = {
     .name = "default",
     .type = AVMEDIA_TYPE_VIDEO,
     .config_props = config_output,
-  },
-  {NULL}
+  }
 };
 
 AVFilter ff_vf_gltransition = {
@@ -623,10 +622,10 @@ AVFilter ff_vf_gltransition = {
   .preinit       = gltransition_framesync_preinit,
   .init          = init,
   .uninit        = uninit,
-  .query_formats = query_formats,
+  FILTER_QUERY_FUNC(query_formats),
   .activate      = activate,
-  .inputs        = gltransition_inputs,
-  .outputs       = gltransition_outputs,
+  FILTER_INPUTS(gltransition_inputs),
+  FILTER_OUTPUTS(gltransition_outputs),
   .priv_class    = &gltransition_class,
   .flags         = AVFILTER_FLAG_SUPPORT_TIMELINE_GENERIC
 };

--- a/vf_gltransition.c
+++ b/vf_gltransition.c
@@ -27,14 +27,13 @@
 # include <GLFW/glfw3.h>
 #endif
 
+#include <SOIL.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <float.h>
 
 #define FROM (0)
 #define TO   (1)
-
-#define PIXEL_FORMAT (GL_RGB)
 
 #ifdef GL_TRANSITION_USING_EGL
 static const EGLint configAttribs[] = {
@@ -99,6 +98,12 @@ typedef struct {
   double duration;
   double offset;
   char *source;
+  char *extra_texture;
+  int alpha;
+
+  // decided by alpha
+  int pix_fmt;
+  int channel_num;
 
   // timestamp of the first frame in the output, in the timebase units
   int64_t first_pts;
@@ -106,6 +111,7 @@ typedef struct {
   // uniforms
   GLuint        from;
   GLuint        to;
+  GLuint        extra_tex;
   GLint         progress;
   GLint         ratio;
   GLint         _fromR;
@@ -133,6 +139,8 @@ static const AVOption gltransition_options[] = {
   { "duration", "transition duration in seconds", OFFSET(duration), AV_OPT_TYPE_DOUBLE, {.dbl=1.0}, 0, DBL_MAX, FLAGS },
   { "offset", "delay before startingtransition in seconds", OFFSET(offset), AV_OPT_TYPE_DOUBLE, {.dbl=0.0}, 0, DBL_MAX, FLAGS },
   { "source", "path to the gl-transition source file (defaults to basic fade)", OFFSET(source), AV_OPT_TYPE_STRING, {.str = NULL}, CHAR_MIN, CHAR_MAX, FLAGS },
+  { "extra_texture", "path to the gl-transition extra_texture file", OFFSET(extra_texture), AV_OPT_TYPE_STRING, {.str = NULL}, CHAR_MIN, CHAR_MAX, FLAGS },
+  { "alpha", "keep alpha channel", OFFSET(alpha), AV_OPT_TYPE_INT, {.dbl=0}, 0, DBL_MAX, FLAGS },
   {NULL}
 };
 
@@ -242,8 +250,7 @@ static void setup_tex(AVFilterLink *fromLink)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, fromLink->w, fromLink->h, 0, PIXEL_FORMAT, GL_UNSIGNED_BYTE, NULL);
-
+    glTexImage2D(GL_TEXTURE_2D, 0, c->pix_fmt, fromLink->w, fromLink->h, 0, c->pix_fmt, GL_UNSIGNED_BYTE, NULL);
     glUniform1i(glGetUniformLocation(c->program, "from"), 0);
   }
 
@@ -257,9 +264,33 @@ static void setup_tex(AVFilterLink *fromLink)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, fromLink->w, fromLink->h, 0, PIXEL_FORMAT, GL_UNSIGNED_BYTE, NULL);
+    glTexImage2D(GL_TEXTURE_2D, 0, c->pix_fmt, fromLink->w, fromLink->h, 0, c->pix_fmt, GL_UNSIGNED_BYTE, NULL);
 
     glUniform1i(glGetUniformLocation(c->program, "to"), 1);
+  }
+
+  if (c->extra_texture) { // extra_texture
+    int width, height, channels, soilPixFmt;
+    soilPixFmt = SOIL_LOAD_RGB;
+    if (c->alpha) {
+      soilPixFmt = SOIL_LOAD_RGBA;
+    }
+    unsigned char* image = SOIL_load_image(c->extra_texture, &width, &height, &channels, soilPixFmt);
+
+    glGenTextures(1, &c->extra_tex);
+    glActiveTexture(GL_TEXTURE0 + 2);
+    glBindTexture(GL_TEXTURE_2D, c->extra_tex);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+
+    glTexImage2D(GL_TEXTURE_2D, 0, c->pix_fmt, width, height, 0, c->pix_fmt, GL_UNSIGNED_BYTE, image);
+
+    glUniform1i(glGetUniformLocation(c->program, "extra_tex"), 2);
+
+    SOIL_free_image_data(image);
   }
 }
 
@@ -397,17 +428,17 @@ static AVFrame *apply_transition(FFFrameSync *fs,
 
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, c->from);
-  glPixelStorei(GL_UNPACK_ROW_LENGTH, fromFrame->linesize[0] / 3);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, fromLink->w, fromLink->h, 0, PIXEL_FORMAT, GL_UNSIGNED_BYTE, fromFrame->data[0]);
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, fromFrame->linesize[0] / c->channel_num);
+  glTexImage2D(GL_TEXTURE_2D, 0, c->pix_fmt, fromLink->w, fromLink->h, 0, c->pix_fmt, GL_UNSIGNED_BYTE, fromFrame->data[0]);
 
   glActiveTexture(GL_TEXTURE0 + 1);
   glBindTexture(GL_TEXTURE_2D, c->to);
-  glPixelStorei(GL_UNPACK_ROW_LENGTH, toFrame->linesize[0] / 3);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, toLink->w, toLink->h, 0, PIXEL_FORMAT, GL_UNSIGNED_BYTE, toFrame->data[0]);
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, toFrame->linesize[0] / c->channel_num);
+  glTexImage2D(GL_TEXTURE_2D, 0, c->pix_fmt, toLink->w, toLink->h, 0, c->pix_fmt, GL_UNSIGNED_BYTE, toFrame->data[0]);
 
   glDrawArrays(GL_TRIANGLES, 0, 6);
-  glPixelStorei(GL_PACK_ROW_LENGTH, outFrame->linesize[0] / 3);
-  glReadPixels(0, 0, outLink->w, outLink->h, PIXEL_FORMAT, GL_UNSIGNED_BYTE, (GLvoid *)outFrame->data[0]);
+  glPixelStorei(GL_PACK_ROW_LENGTH, outFrame->linesize[0] / c->channel_num);
+  glReadPixels(0, 0, outLink->w, outLink->h, c->pix_fmt, GL_UNSIGNED_BYTE, (GLvoid *)outFrame->data[0]);
 
   glPixelStorei(GL_PACK_ROW_LENGTH, 0);
   glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
@@ -493,12 +524,33 @@ static av_cold void uninit(AVFilterContext *ctx) {
 
 static int query_formats(AVFilterContext *ctx)
 {
-  static const enum AVPixelFormat formats[] = {
-    AV_PIX_FMT_RGB24,
-    AV_PIX_FMT_NONE
-  };
+    GLTransitionContext *c = ctx->priv;
+    static const enum AVPixelFormat pix_fmts_rgb[] = {
+        AV_PIX_FMT_RGB24,    AV_PIX_FMT_BGR24,
+        AV_PIX_FMT_ARGB,     AV_PIX_FMT_ABGR,
+        AV_PIX_FMT_RGBA,     AV_PIX_FMT_BGRA,
+        AV_PIX_FMT_NONE
+    };
+    static const enum AVPixelFormat pix_fmts_rgba[] = {
+        AV_PIX_FMT_ARGB,     AV_PIX_FMT_ABGR,
+        AV_PIX_FMT_RGBA,     AV_PIX_FMT_BGRA,
+        AV_PIX_FMT_NONE
+    };
+    AVFilterFormats *fmts_list;
 
-  return ff_set_common_formats(ctx, ff_make_format_list(formats));
+    if (c->alpha) {
+        c->pix_fmt = GL_RGBA;
+        c->channel_num = 4;
+        fmts_list = ff_make_format_list(pix_fmts_rgba);
+    } else {
+        c->pix_fmt = GL_RGB;
+        c->channel_num = 3;
+        fmts_list = ff_make_format_list(pix_fmts_rgb);
+    }
+    if (!fmts_list) {
+      return AVERROR(ENOMEM);
+    }
+    return ff_set_common_formats(ctx, fmts_list);
 }
 
 static int activate(AVFilterContext *ctx)


### PR DESCRIPTION
Try to keep alpha channel, and added input option「extra_texture」to set the third texture like displacement.glsl's displacementMap.
It can be used by command like:
`./ffmpeg -i frames_1/%06d.png -i frames_2/%06d.png -filter_complex "gltransition=duration=2:source=displacement.glsl:extra_texture=radial-tri-lateral.png" -y -start_number 000000 out/%06d.png`

Thx your ffmpeg-gl-transition again, it's awesome.